### PR TITLE
add: .gitignore, cli w/ manpage & makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+### Operating Systems ###
+# Darwin
+.DS_Store
+
+#### go ####
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+vendor/
+

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,0 +1,298 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/nishanths/go-xkcd/v2"
+)
+
+var (
+	comic, latest             xkcd.Comic
+	max, min, id              int   // to help with choosing a random comic // first comic to look for
+	err                       error // to avoid unwanted duplication of variables in lower scopes
+	dir, force, view, clean   bool
+	keep, list, restore, prev bool
+
+	bgctx  context.Context = context.Background()
+	client *xkcd.Client    = xkcd.NewClient()
+
+	randomMode = flag.NewFlagSet("random", flag.ExitOnError) // get a random comic
+	fetchMode  = flag.NewFlagSet("fetch", flag.ExitOnError)  // get a particular comic - defaults to random
+	configMode = flag.NewFlagSet("config", flag.ExitOnError) // open settings file in json editor
+	helpMode   = flag.NewFlagSet("help", flag.ExitOnError)
+	likeMode   = flag.NewFlagSet("likes", flag.ExitOnError)
+	modes      = map[string]*flag.FlagSet{
+		randomMode.Name(): randomMode,
+		fetchMode.Name():  fetchMode,
+		configMode.Name(): configMode,
+		helpMode.Name():   helpMode,
+		likeMode.Name():   likeMode,
+	}
+
+	settings    = &Settings{}
+	comicFolder = filepath.Join(filepath.Dir(settings.Path()), "comics")
+)
+
+func setLatestComic(force bool) error {
+	if force || time.Since(settings.LastCheck) > 24*time.Hour {
+		if latest, err = client.Latest(bgctx); err != nil {
+			return err
+		}
+		settings.LastCheck = time.Now()
+		settings.Latest = latest
+		if err = settings.Save(); err != nil {
+			return err
+		}
+	} else {
+		latest = settings.Latest
+	}
+	max = latest.Number
+	id = latest.Number
+	return nil
+}
+
+func help(modeName string) {
+	mode, exists := modes[modeName]
+	if exists {
+		fmt.Println(modeName)
+		mode.PrintDefaults()
+		if modeName == helpMode.Name() {
+			fmt.Println("  Print this information")
+		} else if modeName == configMode.Name() {
+			fmt.Printf("config located @ %q\n", settings.Path())
+		}
+	}
+}
+
+func restoreLikes() {
+	ctx, cancel := context.WithCancel(bgctx)
+	defer cancel()
+	for _, index := range settings.Likes {
+		comic, err := client.Get(ctx, index)
+		// comic, err := client.Get(context.Background(), index)
+		if err != nil {
+			internalError.Abortf("Restoring Likes: Comic number %d doesn't exist or couldn't be accessed. Double check your connection and try again:\n\t%s", id, err)
+		}
+		_, err = DownloadFile(comic.ImageURL)
+		if err != nil {
+			internalError.Abort(err.Error())
+		}
+	}
+}
+
+// func getComic(id int) error {}
+
+func displayComic(id int) {
+	comic, err := client.Get(bgctx, id)
+	if err != nil {
+		userInputError.Abortf("Cannot display comic number %d as it doesn't exist or couldn't be accessed. Double check your connection and try again:\n\t%s", id, err)
+	}
+
+	fmt.Printf("Comic #%d: %s\n", comic.Number, comic.Title)
+	path, err := DownloadFile(comic.ImageURL)
+	if err != nil {
+		internalError.Abort(err.Error())
+	}
+	Open(path)
+
+	settings.LastSaw = comic
+	if err = settings.Save(); err != nil {
+		internalError.Abortf("Couldn't save settings after displaying comic #%d: %s", id, err)
+	}
+}
+
+func comicName(id int) string {
+	comic, err := client.Get(context.Background(), id)
+	if err != nil {
+		internalError.Abortf("Couldn't get the name of comic #%d: %s\n\tDouble check your internet connection\n", id, err)
+	}
+	return filepath.Base(comic.ImageURL)
+}
+
+func cleanUp() error {
+	faveNames := []string{}
+	for _, index := range settings.Likes {
+		faveNames = append(faveNames, comicName(index))
+	}
+	for _, name := range Files(comicFolder) {
+		if !containsStr(faveNames, filepath.Base(name)) {
+			err := os.Remove(name)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func userLikes() map[int]string {
+	table := make(map[int]string)
+	for _, index := range settings.Likes {
+		table[index] = comicName(index)
+	}
+	return table
+}
+
+func Usage() {
+	fmt.Println("Usage of", os.Args[0], "[mode]", "[params]")
+	for name := range modes {
+		help(name)
+		fmt.Println()
+	}
+
+	fmt.Printf("all comics downloaded to %q\n", comicFolder)
+}
+
+func main() {
+	min = 1
+	err = settings.Load()
+	if err != nil && err != io.EOF {
+		internalError.Abortf("Couldn't load settings: %s", err)
+	}
+	keep = settings.Keep
+
+	if err = setLatestComic(false); err != nil {
+		internalError.Abortf("Couldn't get the index for the latest comic. %s\n\tDouble check your internet connection", err)
+	}
+
+	randomMode.IntVar(&max, "max", max, "the maximum index for a random comic (double-check your internet connection if the default is zero)")
+	randomMode.IntVar(&min, "min", min, "the minimum index for a random comic")
+
+	fetchMode.IntVar(&id, "id", id, "the index of the comic you want to see")
+	fetchMode.BoolVar(&force, "f", force, "grab the latest comic even if checked within the last 24 hours")
+
+	configMode.BoolVar(&keep, "k", keep, "Toggle whether or not to keep comics after displaying them (default: false)")
+	configMode.BoolVar(&dir, "d", dir, "Open the directory of the config file, instead of the file itself")
+
+	likeMode.BoolVar(&view, "v", view, "View your likes")
+	likeMode.BoolVar(&clean, "c", clean, "Clean up. (removes all saved comics that aren't liked)")
+	likeMode.BoolVar(&list, "l", list, "list the names of the comics you've liked")
+	likeMode.BoolVar(&restore, "r", restore, "Re-download any missing likes")
+	likeMode.BoolVar(&prev, "p", prev, "Add previous comic to likes")
+
+	flag.Usage = Usage
+
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case likeMode.Name():
+			err = likeMode.Parse(os.Args[2:])
+			if err != nil {
+				userInputError.Abortf("Couldn't parse args %s", err)
+			}
+			if prev {
+				settings.Likes = append(settings.Likes, settings.LastSaw.Number)
+				err = settings.Save()
+				if err != nil {
+					internalError.Abortf("Couldn't save settings: %s", err)
+				}
+				return
+			} else if view {
+				for _, index := range settings.Likes {
+					displayComic(index)
+				}
+				return
+			} else if list {
+				for _, index := range settings.Likes {
+					fmt.Printf("%d:\t%s\n", index, comicName(index))
+				}
+				return
+			} else if clean {
+				cleanUp()
+				return
+			} else if restore {
+				restoreLikes()
+				return
+			}
+			for _, arg := range os.Args[2:] {
+				v, err := strconv.ParseInt(arg, 0, 0)
+				if err != nil {
+					userInputError.Abortf("Couldn't parse %q: %s", arg, err)
+				}
+				if !containsInt(settings.Likes, int(v)) {
+					settings.Likes = append(settings.Likes, int(v))
+				}
+			}
+
+			err = settings.Save()
+			if err != nil {
+				internalError.Abortf("Couldn't save settings: %s", err)
+			}
+			return
+		case helpMode.Name():
+			err = helpMode.Parse(os.Args[2:])
+			if err != nil {
+				userInputError.Abortf("Couldn't parse args %s", err)
+			}
+			if len(os.Args) == 2 {
+				flag.Usage()
+			} else {
+				for _, name := range os.Args[2:] {
+					help(name)
+				}
+			}
+			return
+		case configMode.Name():
+			err = configMode.Parse(os.Args[2:])
+			if err != nil {
+				userInputError.Abortf("Couldn't parse args %s", err)
+			}
+			if keep {
+				settings.Keep = !settings.Keep
+				return
+			}
+			err = settings.Open(dir)
+			if err != nil {
+				internalError.Abortf("Couldn't open settings: %s", err)
+			}
+			return
+		case randomMode.Name():
+			err = randomMode.Parse(os.Args[2:])
+			if err != nil {
+				userInputError.Abortf("Couldn't parse args %s", err)
+			}
+			rand.Seed(time.Now().Unix())
+			if max > min {
+				id = min + rand.Intn(max-min)
+			} else {
+				id = max + rand.Intn(min-max)
+			}
+		case fetchMode.Name():
+			err = fetchMode.Parse(os.Args[2:])
+			if err != nil {
+				userInputError.Abortf("Couldn't parse args %s", err)
+			}
+		case "next":
+			id = settings.LastSaw.Number
+			if id <= settings.Latest.Number-1 {
+				id++
+			} else {
+				id = 1
+			}
+		case "prev":
+			id = settings.LastSaw.Number
+			if id >= 2 {
+				id--
+			} else {
+				id = latest.Number
+			}
+		default:
+			flag.Usage()
+			flag.PrintDefaults()
+			userInputError.Abortf("Couldn't parse args: %s", os.Args[1:])
+		}
+	} else {
+		flag.Usage()
+		flag.PrintDefaults()
+		noError.Abort("")
+	}
+
+	displayComic(id)
+}

--- a/cli/errors.go
+++ b/cli/errors.go
@@ -1,0 +1,52 @@
+/*
+   A template for adding descriptive error reports to a command line interface
+*/
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+const (
+	noError ErrorCode = iota
+	internalError
+	userInputError
+	warning
+)
+
+type ErrorCode int
+
+func (this ErrorCode) Error() string {
+	return []string{"NO ERROR", "INTERNAL ERROR", "USER INPUT ERROR", "WARNING"}[this]
+}
+
+func (this ErrorCode) Abort(message string) {
+	this.Warn(message)
+	if this == userInputError {
+		flag.Usage()
+	}
+	os.Exit(int(this))
+}
+
+func (this ErrorCode) Abortf(message string, args ...interface{}) {
+	this.Warnf(message, args...)
+	if this == userInputError {
+		flag.Usage()
+	}
+	os.Exit(int(this))
+}
+
+func (this ErrorCode) Warn(message string) {
+	if this >= internalError {
+		fmt.Fprint(os.Stderr, fmt.Errorf("[%s]: %s\n", this.Error(), message))
+	}
+}
+
+func (this ErrorCode) Warnf(message string, args ...interface{}) {
+	message = fmt.Sprintf(message, args...)
+	if this >= internalError {
+		fmt.Fprint(os.Stderr, fmt.Errorf("[%s]: %s\n", this.Error(), message))
+	}
+}

--- a/cli/errors.go
+++ b/cli/errors.go
@@ -1,6 +1,5 @@
 /*
    A template for adding descriptive error reports to a command line interface
-																						   - kendfss
 */
 package main
 

--- a/cli/errors.go
+++ b/cli/errors.go
@@ -1,5 +1,6 @@
 /*
    A template for adding descriptive error reports to a command line interface
+																						   - kendfss
 */
 package main
 

--- a/cli/itertools.go
+++ b/cli/itertools.go
@@ -1,0 +1,25 @@
+package main
+
+func Merge(receiver *[]string, giver []string) {
+	for _, str := range giver {
+		*receiver = append(*receiver, str)
+	}
+}
+
+func containsInt(rack []int, item int) bool {
+	for _, elem := range rack {
+		if elem == item {
+			return true
+		}
+	}
+	return false
+}
+
+func containsStr(rack []string, item string) bool {
+	for _, elem := range rack {
+		if elem == item {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/main.go
+++ b/cli/main.go
@@ -59,17 +59,37 @@ func setLatestComic(force bool) error {
 	return nil
 }
 
+func Usage() {
+	fmt.Fprintf(os.Stderr, "Usage of %s [mode] [params]\n", os.Args[0])
+	for name := range modes {
+		help(name)
+		fmt.Fprintf(os.Stderr, "\n")
+	}
+
+	fmt.Fprintf(os.Stderr, "all comics downloaded to %q\n", comicFolder)
+}
+
+// Get info for a specific mode
+// non-existant arguments will be ignored
 func help(modeName string) {
 	mode, exists := modes[modeName]
 	if exists {
-		fmt.Println(modeName)
+		fmt.Fprintf(os.Stderr, modeName+"\n")
 		mode.PrintDefaults()
 		if modeName == helpMode.Name() {
-			fmt.Println("  Print this information")
+			fmt.Fprintf(os.Stderr, "  Print this information\n")
 		} else if modeName == configMode.Name() {
-			fmt.Printf("config located @ %q\n", settings.Path())
+			fmt.Fprintf(os.Stderr, "\tconfig file located @ %q\n", settings.Path())
 		}
 	}
+}
+
+func userLikes() map[int]string {
+	table := make(map[int]string)
+	for _, index := range settings.Likes {
+		table[index] = comicName(index)
+	}
+	return table
 }
 
 func restoreLikes() {
@@ -77,7 +97,6 @@ func restoreLikes() {
 	defer cancel()
 	for _, index := range settings.Likes {
 		comic, err := client.Get(ctx, index)
-		// comic, err := client.Get(context.Background(), index)
 		if err != nil {
 			internalError.Abortf("Restoring Likes: Comic number %d doesn't exist or couldn't be accessed. Double check your connection and try again:\n\t%s", id, err)
 		}
@@ -87,8 +106,6 @@ func restoreLikes() {
 		}
 	}
 }
-
-// func getComic(id int) error {}
 
 func displayComic(id int) {
 	comic, err := client.Get(bgctx, id)
@@ -133,24 +150,6 @@ func cleanUp() error {
 	return nil
 }
 
-func userLikes() map[int]string {
-	table := make(map[int]string)
-	for _, index := range settings.Likes {
-		table[index] = comicName(index)
-	}
-	return table
-}
-
-func Usage() {
-	fmt.Println("Usage of", os.Args[0], "[mode]", "[params]")
-	for name := range modes {
-		help(name)
-		fmt.Println()
-	}
-
-	fmt.Printf("all comics downloaded to %q\n", comicFolder)
-}
-
 func main() {
 	min = 1
 	err = settings.Load()
@@ -169,7 +168,7 @@ func main() {
 	fetchMode.IntVar(&id, "id", id, "the index of the comic you want to see")
 	fetchMode.BoolVar(&force, "f", force, "grab the latest comic even if checked within the last 24 hours")
 
-	configMode.BoolVar(&keep, "k", keep, "Toggle whether or not to keep comics after displaying them (default: false)")
+	configMode.BoolVar(&keep, "k", keep, "Toggle whether or not to keep comics after displaying them"+fmt.Sprintf(" (currently '%t')", settings.Keep))
 	configMode.BoolVar(&dir, "d", dir, "Open the directory of the config file, instead of the file itself")
 
 	likeMode.BoolVar(&view, "v", view, "View your likes")
@@ -284,13 +283,10 @@ func main() {
 				id = latest.Number
 			}
 		default:
-			flag.Usage()
-			flag.PrintDefaults()
-			userInputError.Abortf("Couldn't parse args: %s", os.Args[1:])
+			userInputError.Abortf("Cannot interpret mode/command: %q", os.Args[1])
 		}
 	} else {
 		flag.Usage()
-		flag.PrintDefaults()
 		noError.Abort("")
 	}
 

--- a/cli/makefile
+++ b/cli/makefile
@@ -1,0 +1,94 @@
+projdir = $(shell pwd)
+projname = "xkcd"
+
+installdir = $(GOPATH)/bin
+builddir = $(projdir)/bin
+
+buildpath = $(builddir)/$(projname)
+installpath = $(installdir)/$(projname)
+
+ifeq ($(shell uname),Linux)
+	mandir := /usr/local/man/man1
+	LINUX := 1
+endif
+ifeq ($(shell uname),Darwin)
+	mandir := /usr/local/share/man/man1
+	DARWIN := 1
+endif
+
+manfile = man_page.md
+gruffarchive = $(mandir)/$(projname)
+gruffpath = $(gruffarchive).1
+
+PANDOC = $(shell which pandoc)
+
+.PHONY: tidy update fmt run build_bin build_docs install_bin install_docs install docs test_doc remove
+
+default: install
+install: install_bin install_docs
+remove: remove_install remove_docs
+
+tidy:
+	@go mod tidy
+
+update:
+	git fetch
+	git merge
+	$(MAKE) -s tidy
+
+upgrade: update
+	$(MAKE) -s default
+
+fmt:
+	@gofmt -w .
+
+run: tidy fmt
+	@go run .
+
+build_bin: tidy fmt
+	@rm -f $(buildpath)
+	@mkdir -p $(builddir)
+	@go build -o $(buildpath)
+	@chmod +x $(buildpath)
+	@echo "Successfully built \"$(projname)\" into $(buildpath)"
+
+install_bin: build_bin
+	@rm -f $(installpath)
+	@mv $(buildpath) $(installpath)
+	@echo "Successfully installed \"$(projname)\" at \"$(installpath)\""
+	@rm -rf $(builddir)
+
+	
+
+build_docs: $(PANDOC)
+	@pandoc $(projdir)/man_page.md -s -t man -o $(projdir)/$(projname).1
+
+install_docs: $(mandir) build_docs
+	@mkdir -p $(mandir)
+	@sudo mv $(projname).1 $(gruffpath)
+	@echo "Successfully installed man-page at $(gruffpath)"
+	@echo ""
+
+test_doc: $(PANDOC) build_docs
+	man $(projname).1
+	@rm $(projname).1
+	@echo "Successfully tested docs!"
+
+
+remove_install:
+	@sudo rm -rf $(builddir)
+	@echo "Erased build directory from \"$(builddir)\""
+
+	@sudo rm -f $(installpath)
+	@echo "Erased installation from \"$(installpath)\""
+
+remove_docs: $(mandir)
+	@sudo rm -f $(gruffpath)
+	@echo "Erased man-page gruff file from \"$(gruffpath)\""
+
+	@sudo rm -f $(gruffarchive)
+	@echo "Erased man-page archive from \"$(gruffarchive)\""
+
+update_manpages: $(LINUX)
+	@sudo mandb
+	@echo "Updated man-pages"

--- a/cli/man_page.md
+++ b/cli/man_page.md
@@ -1,0 +1,64 @@
+# Name
+**xkcd** - download XKCD comics
+
+# Synopsis
+**xkcd** [mode] [params]
+
+# Description
+**xkcd** download and view xkcd comics by index or at random. 
+
+# Options
+**config**
+  -d  Open the directory of the config file, instead of the file itself
+  -k  Toggle whether or not to keep comics after displaying them (default: false)
+config located @ `~/.local/share/xkcd/settings.json`
+
+**fetch**
+  -f  grab the latest comic even if checked within the last 24 hours
+  -id int
+      the index of the comic you want to see (default 2532)
+
+**likes**
+  -c  Clean up. (removes all saved comics that aren't liked)
+  -l  list the names of the comics you've liked
+  -p  Add previous comic to likes
+  -r  Re-download any missing likes
+  -v  View your likes
+
+**random**
+  -max int
+      the maximum index for a random comic (double-check your internet connection if the default is zero) (default 2532)
+  -min int
+      the minimum index for a random comic (default 1)
+
+**help**
+  Print this information
+
+all comics downloaded to `~/.local/share/xkcd/comics`
+
+
+# Examples
+
+**xkcd** help [random]  
+    # info on a given mode
+**xkcd** next  
+    # fetch the comic whose index is one before the last one you saw
+**xkcd** prev  
+    # fetch the comic whose index is one greater than the last comic you saw
+**xkcd** random -max 22  
+    # fetch a random comic whose index is smaller than 22
+**xkcd** likes 12  
+    # adds comic number 12 to your likes
+**xkcd** fetch -f 
+    # fetch the latest comic even if you checked for it in the past 24 hours
+
+
+
+# Exit Values
+**0** No Error  
+**1** Internal Error  
+**2** User Input Error  
+**3** Warning
+
+# License
+MIT  

--- a/cli/pathtools.go
+++ b/cli/pathtools.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"io"
+	"io/fs"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+)
+
+func Listdir(pth string) []string {
+	files, err := os.ReadDir(pth)
+	if err != nil {
+		internalError.Abort(err.Error())
+	}
+	rack := make([]string, 0)
+	for _, file := range files {
+		rack = append(rack, file.Name())
+	}
+	return rack
+}
+func Files(root string) []string {
+	paths := make([]string, 0)
+	for _, name := range Listdir(root) {
+		pth := filepath.Join(root, name)
+		stat, err := os.Lstat(pth)
+		if err != nil {
+			internalError.Abort(err.Error())
+		}
+		switch mode := stat.Mode(); {
+		case mode.IsRegular():
+			paths = append(paths, pth)
+		case mode.IsDir():
+			go Merge(&paths, Files(pth))
+		}
+	}
+	return paths
+}
+
+func Open(path string) error {
+	var (
+		cmd *exec.Cmd
+	)
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", path)
+	case "linux":
+		cmd = exec.Command("xdg-open", path)
+	case "windows":
+		cmd = exec.Command("start", path)
+	default:
+		internalError.Abort("Do not know how to open files on this Operating System")
+	}
+	return cmd.Run()
+}
+
+func DownloadFile(url string) (string, error) {
+	_, err := os.Stat(comicFolder)
+	if os.IsNotExist(err) {
+		err := os.MkdirAll(comicFolder, fs.ModeDir|fs.ModePerm)
+		if err != nil {
+			return "", err
+		}
+	}
+	path := filepath.Join(comicFolder, filepath.Base(url))
+	// avoid downloading the same comic twice
+	_, err = os.Stat(path)
+	if !os.IsNotExist(err) {
+		return path, nil
+	}
+	out, err := os.Create(path)
+	if err != nil {
+		return "", err
+	}
+	defer out.Close()
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return path, nil
+}

--- a/cli/readme.md
+++ b/cli/readme.md
@@ -1,0 +1,49 @@
+xkcd-cli
+---
+
+A command-line interface to the example in the outer repository.  
+**xkcd** allows the user to download and view xkcd comics by index (`fetch` mode) or at random, as well as keeping track of favourite comics (`like` mode).  
+  
+You may also find more robust documentation by running `man xkcd`, after installing.  
+
+## Install
+```shell
+git clone https://github.com/nishanths/go-xkcd
+cd go-xkcd/cli
+make
+```
+
+## Uninstall
+```shell
+make remove
+```
+- This _will not_ delete downloaded comics or settings under `~/.local/share/xkcd`  
+
+## Usage
+```shell
+xkcd [mode] [params]
+```
+modes:
+- `config`  
+- `fetch`  
+- `likes`  
+- `random`  
+- `help`  
+
+## Examples
+```shell
+xkcd help [mode]  # info on a given mode
+xkcd next  # fetch the comic whose index is one before the last one you saw
+xkcd prev  # fetch the comic whose index is one greater than the last comic you saw
+xkcd fetch -f  # fetch the latest comic even if you checked for it in the past 24 hours
+xkcd random  # fetch a random
+xkcd random -max 22  # fetch a random comic whose index is smaller than 22
+xkcd likes 12  # add comic number 12 to your likes
+```
+
+## Exit Values
+- `0` No Error  
+- `1` Internal Error  
+- `2` User Input Error  
+- `3` Warning  
+

--- a/cli/settings.go
+++ b/cli/settings.go
@@ -1,0 +1,134 @@
+/*
+   A template for adding persistent & accessible configuration systems to CLIs
+*/
+package main
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+
+	// the following packages are only used for this particular project
+	"github.com/nishanths/go-xkcd/v2"
+	"time"
+)
+
+const (
+	PROJECTNAME = "xkcd" // For creating a user-accessible data directory
+)
+
+var (
+	//go:embed settings.json
+	defaultSettings []byte
+)
+
+type (
+	Settings struct {
+		Keep      bool       `json:"keep"`
+		Latest    xkcd.Comic `json:"latest"`
+		LastSaw   xkcd.Comic `json:"lastSaw"`
+		LastCheck time.Time  `json:"lastCheck"`
+		Likes     []int      `json:"likes"`
+	}
+)
+
+func (these Settings) Loadable() bool {
+	if _, err := os.Stat(these.Path()); err != nil {
+		return false
+	}
+	return true
+}
+func (these Settings) Exist() bool {
+	_, err := os.Stat(these.Path())
+	return !os.IsNotExist(err)
+}
+func (these *Settings) Load() error {
+	if these.Exist() {
+		data, err := ioutil.ReadFile(these.Path())
+		if err != nil {
+			return err
+		}
+		return json.Unmarshal(data, these)
+	}
+	if len(defaultSettings) > 0 {
+		return json.Unmarshal(defaultSettings, these)
+	}
+	// default settings need to be created if they haven't already been
+	data, err := json.MarshalIndent(these, "", "  ")
+	if err != nil {
+		return err
+	}
+	defaultSettings = data
+	if err = ioutil.WriteFile("settings.json", data, fs.ModePerm); err != nil {
+		return err
+	}
+	return these.Load() // try again
+}
+
+func (these *Settings) Restore() error {
+	err := os.Remove(these.Path())
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(defaultSettings, these)
+}
+
+func (these Settings) Assure() error {
+	dir := filepath.Dir(these.Path())
+	return os.MkdirAll(dir, fs.ModeDir|fs.ModePerm)
+}
+
+func (these *Settings) Save() error {
+	data, err := json.MarshalIndent(these, "", "  ")
+	if err == nil {
+		these.Assure()
+		return ioutil.WriteFile(these.Path(), data, fs.ModePerm)
+	}
+	return fmt.Errorf("Couldn't save settings file: %w", err)
+}
+
+// This is used to generate an initial copy of the configuration file
+// Do not use unless you are comfortable with a "settings.json" file
+// in your current directory
+func (these *Settings) Overwrite() error {
+	data, err := json.MarshalIndent(these, "", "  ")
+	if err == nil {
+		internalError.Abortf("Couldn't save settings file: %w", err)
+	}
+	return ioutil.WriteFile("settings.json", data, fs.ModePerm)
+}
+
+func (these Settings) Open(dir bool) error {
+	var (
+		cmd  *exec.Cmd
+		path string = these.Path()
+	)
+	if dir {
+		path = filepath.Dir(path)
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", path)
+	case "linux":
+		cmd = exec.Command("xdg-open", path)
+	case "windows":
+		cmd = exec.Command("start", path)
+	default:
+		internalError.Abort("Do not know how to open files on this Operating System")
+	}
+	return cmd.Run()
+}
+
+func (these Settings) Path() string {
+	user, err := os.UserHomeDir()
+	if err != nil {
+		internalError.Abort(err.Error())
+	}
+	return filepath.Join(user, ".local", "share", PROJECTNAME, "settings.json")
+}

--- a/cli/settings.go
+++ b/cli/settings.go
@@ -1,5 +1,6 @@
 /*
    A template for adding persistent & accessible configuration systems to CLIs
+																						   - kendfss
 */
 package main
 

--- a/cli/settings.go
+++ b/cli/settings.go
@@ -1,6 +1,5 @@
 /*
    A template for adding persistent & accessible configuration systems to CLIs
-																						   - kendfss
 */
 package main
 

--- a/cli/settings.go
+++ b/cli/settings.go
@@ -1,5 +1,6 @@
 /*
    A template for adding persistent & accessible configuration systems to CLIs
+                                                                                           - kendfss
 */
 package main
 

--- a/cli/settings.json
+++ b/cli/settings.json
@@ -1,0 +1,31 @@
+{
+  "keep": false,
+  "latest": {
+    "Alt": "",
+    "Day": 0,
+    "ImageURL": "",
+    "URL": "",
+    "Month": 0,
+    "News": "",
+    "Number": 0,
+    "SafeTitle": "",
+    "Title": "",
+    "Transcript": "",
+    "Year": 0
+  },
+  "lastSaw": {
+    "Alt": "",
+    "Day": 0,
+    "ImageURL": "",
+    "URL": "",
+    "Month": 0,
+    "News": "",
+    "Number": 0,
+    "SafeTitle": "",
+    "Title": "",
+    "Transcript": "",
+    "Year": 0
+  },
+  "lastCheck": "0001-01-01T00:00:00Z",
+  "likes": null
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/nishanths/go-xkcd/v2
 
-go 1.14
+go 1.16


### PR DESCRIPTION
Just adds a command line interface to the library.
Not sure if makefile should go in home or not. Should just need to add `/cli` to `projdir` variable in makefile if so.

Man pages are only supported for linux and darwin systems right now
  
Here's the main part of the readme:

## Usage
```shell
xkcd [mode] [params]
```
modes:
- `config`  
- `fetch`  
- `likes`  
- `random`  
- `help`  

## Examples
```shell
xkcd help [mode]  # info on a given mode
xkcd next  # fetch the comic whose index is one before the last one you saw
xkcd prev  # fetch the comic whose index is one greater than the last comic you saw
xkcd fetch -f  # fetch the latest comic even if you checked for it in the past 24 hours
xkcd random  # fetch a random
xkcd random -max 22  # fetch a random comic whose index is smaller than 22
xkcd likes 12  # add comic number 12 to your likes
```

## Install
```shell
git clone https://github.com/nishanths/go-xkcd
cd go-xkcd/cli
make
```